### PR TITLE
feat: make ontime-web fully mobile responsive

### DIFF
--- a/src/app/driver/page.tsx
+++ b/src/app/driver/page.tsx
@@ -39,15 +39,8 @@ export default function DriverStatusPage() {
         <TopAppBar title="Driver Status" />
 
         <div
-          className="page-enter"
-          style={{
-            paddingTop: "88px",
-            paddingLeft: "2rem",
-            paddingRight: "2rem",
-            paddingBottom: "3rem",
-            maxWidth: "960px",
-            margin: "0 auto",
-          }}
+          className="page-enter page-content-padded"
+          style={{ maxWidth: "960px", margin: "0 auto" }}
         >
           {/* Page Header */}
           <div style={{ marginBottom: "2rem" }}>
@@ -214,13 +207,7 @@ export default function DriverStatusPage() {
           </div>
 
           {/* Status Grid */}
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "repeat(3, 1fr)",
-              gap: "1rem",
-            }}
-          >
+          <div className="status-grid">
             {STATUS_OPTIONS.map((option) => {
               const isSelected = activeStatus === option.id;
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -751,26 +751,272 @@ select {
 }
 
 /* =============================================
-   RESPONSIVE
+   BOTTOM NAVIGATION (mobile only)
+   ============================================= */
+
+.bottom-nav {
+  display: none;
+}
+
+.bottom-nav-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.625rem;
+  font-weight: 600;
+  color: #64748b;
+  text-decoration: none;
+  flex: 1;
+  justify-content: center;
+  transition: color 0.15s ease;
+}
+
+.bottom-nav-item.active {
+  color: var(--color-primary);
+}
+
+/* =============================================
+   RESPONSIVE LAYOUT CLASSES
+   ============================================= */
+
+/* Home page two-column grid */
+.home-grid {
+  display: grid;
+  grid-template-columns: 5fr 7fr;
+  gap: 2rem;
+  align-items: start;
+}
+
+/* Home page map height */
+.home-map {
+  height: 600px;
+  border-radius: var(--radius-lg);
+  position: relative;
+  overflow: hidden;
+  box-shadow: var(--shadow-ambient);
+}
+
+/* Shared page content padding */
+.page-content-padded {
+  padding-top: 88px;
+  padding-left: 2rem;
+  padding-right: 2rem;
+  padding-bottom: 3rem;
+}
+
+/* Stops page — floating search bar */
+.stops-search-bar {
+  position: absolute;
+  top: 88px;
+  left: 280px;
+  right: 1.5rem;
+  border-radius: var(--radius-lg);
+  padding: 0.75rem 1.25rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  z-index: 10;
+}
+
+/* Stops page — stop list panel */
+.stops-list-panel {
+  position: absolute;
+  bottom: 1.5rem;
+  right: 50px;
+  width: 360px;
+  max-height: calc(100vh - 200px);
+  border-radius: var(--radius-xl);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+  overflow-y: auto;
+  z-index: 10;
+}
+
+/* Tracking page — info panel */
+.tracking-info-panel {
+  position: absolute;
+  top: 88px;
+  right: 32px;
+  width: 360px;
+  max-height: calc(100vh - 112px);
+  border-radius: var(--radius-xl);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  overflow-y: auto;
+  z-index: 10;
+}
+
+/* Sort chips row */
+.sort-chips {
+  display: flex;
+  gap: 0.5rem;
+}
+
+/* Bus card row */
+.bus-card-row {
+  padding: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+/* Driver status grid */
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+/* =============================================
+   RESPONSIVE — ≤768 px
    ============================================= */
 
 @media (max-width: 768px) {
+  /* Hide sidebar, show bottom nav */
   .sidebar {
     display: none;
   }
 
+  .bottom-nav {
+    display: flex;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 64px;
+    background-color: #ffffff;
+    border-top: 1px solid #f1f5f9;
+    box-shadow: 0 -4px 16px rgba(25, 28, 29, 0.06);
+    z-index: 40;
+    align-items: center;
+  }
+
+  /* Top bar spans full width, tighter padding */
   .top-app-bar {
     width: 100%;
+    padding: 0 1rem;
+  }
+
+  /* Push scrollable content above bottom nav */
+  .main-content {
+    margin-left: 0;
+    padding-bottom: 64px;
+  }
+
+  /* Notification panel full-width */
+  aside[role="dialog"] {
+    width: 100% !important;
+  }
+
+  /* Home: stack search + map vertically */
+  .home-grid {
+    grid-template-columns: 1fr;
+  }
+
+  /* Home: shorter map on mobile */
+  .home-map {
+    height: 260px;
+  }
+
+  /* Reduce page padding */
+  .page-content-padded {
+    padding: 80px 1rem 1.5rem;
+  }
+
+  /* Stops search bar: flush to screen edges */
+  .stops-search-bar {
+    left: 1rem;
+    right: 1rem;
+    top: 72px;
+  }
+
+  /* Stops list: full-width bottom sheet above nav */
+  .stops-list-panel {
+    right: 0;
+    left: 0;
+    bottom: 64px;
+    width: 100%;
+    max-height: 42vh;
+    border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+    padding: 1rem;
+  }
+
+  /* Tracking info: full-width bottom sheet above nav */
+  .tracking-info-panel {
+    top: auto;
+    right: 0;
+    left: 0;
+    bottom: 64px;
+    width: 100%;
+    max-height: 42vh;
+    border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+  }
+
+  /* Sort chips: horizontal scroll */
+  .sort-chips {
+    overflow-x: auto;
+    padding-bottom: 0.25rem;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+
+  .sort-chips::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* Sort chips — don't shrink */
+  .sort-chips > * {
+    flex-shrink: 0;
+  }
+
+  /* Driver status: 2 columns on tablet-sized mobile */
+  .status-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+}
+
+/* =============================================
+   RESPONSIVE — ≤480 px (small phones)
+   ============================================= */
+
+@media (max-width: 480px) {
+  /* Bus card: stack info above CTA button */
+  .bus-card-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .bus-card-cta {
+    width: 100% !important;
+    justify-content: center;
+  }
+
+  /* Stop header: wrap icon + text */
+  .stop-header {
+    flex-wrap: wrap;
+  }
+
+  /* Driver status: single column on small phones */
+  .status-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  /* Smaller headline on home */
+  .home-headline {
+    font-size: 1.75rem !important;
   }
 }
 
 /* =============================================
    NOTIFICATION PANEL
    ============================================= */
-
-/* Full-width panel on mobile */
-@media (max-width: 768px) {
-  aside[role="dialog"] {
-    width: 100% !important;
-  }
-}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import BottomNav from "@/components/BottomNav";
 
 export const metadata: Metadata = {
   title: "On Time - Public Transport System",
@@ -14,6 +15,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         {/* Google Fonts — loaded via public CDN (no npm package needed) */}
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
@@ -27,7 +29,10 @@ export default function RootLayout({
           rel="stylesheet"
         />
       </head>
-      <body>{children}</body>
+      <body>
+        {children}
+        <BottomNav />
+      </body>
     </html>
   );
 }

--- a/src/app/nearby/page.tsx
+++ b/src/app/nearby/page.tsx
@@ -134,6 +134,7 @@ function NearbyBusesContent() {
             minHeight: "calc(100vh - 64px)",
             backgroundColor: "var(--color-surface-container-low)",
             padding: "2rem",
+            boxSizing: "border-box",
           }}
         >
           {/* Breadcrumb */}
@@ -163,7 +164,7 @@ function NearbyBusesContent() {
             style={{
               marginBottom: "1.5rem",
               display: "flex",
-              alignItems: "center",
+              alignItems: "flex-start",
               justifyContent: "space-between",
               flexWrap: "wrap",
               gap: "1rem",
@@ -187,7 +188,7 @@ function NearbyBusesContent() {
             </div>
 
             {/* Sort Chips */}
-            <div style={{ display: "flex", gap: "0.5rem" }}>
+            <div className="sort-chips">
               {SORT_OPTIONS.map((opt, i) => (
                 <button
                   key={opt}
@@ -308,17 +309,9 @@ function NearbyBusesContent() {
               sortedBuses.map((route) => (
               <div
                 key={route.id}
-                className="card"
+                className="card bus-card-row"
                 onClick={() => handleSelectBus(route.id)}
-                style={{
-                  padding: "1.5rem",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  opacity: route.status === "delayed" ? 0.9 : 1,
-                  cursor: "pointer",
-                  transition: "transform 0.15s ease, box-shadow 0.15s ease",
-                }}
+                style={{ opacity: route.status === "delayed" ? 0.9 : 1 }}
                 onMouseEnter={(e) => {
                   (e.currentTarget as HTMLDivElement).style.transform = "translateY(-2px)";
                   (e.currentTarget as HTMLDivElement).style.boxShadow = "var(--shadow-elevated)";
@@ -428,7 +421,7 @@ function NearbyBusesContent() {
                 {/* CTA */}
                 <button
                   onClick={(e) => { e.stopPropagation(); handleSelectBus(route.id); }}
-                  className="btn-primary"
+                  className="btn-primary bus-card-cta"
                   style={{
                     width: "auto",
                     padding: "0.75rem 1.5rem",

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -151,15 +151,8 @@ export default function NotificationsPage() {
         <TopAppBar title="Service Alerts" />
 
         <div
-          className="page-enter"
-          style={{
-            paddingTop: "88px",
-            paddingLeft: "2rem",
-            paddingRight: "2rem",
-            paddingBottom: "3rem",
-            maxWidth: "800px",
-            margin: "0 auto",
-          }}
+          className="page-enter page-content-padded"
+          style={{ maxWidth: "800px", margin: "0 auto" }}
         >
           {/* Header */}
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "1.5rem", flexWrap: "wrap", gap: "0.75rem" }}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -174,24 +174,10 @@ export default function RoutesPage() {
         <TopAppBar title="On Time" />
 
         <div
-          className="page-enter"
-          style={{
-            paddingTop: "88px",
-            paddingLeft: "2rem",
-            paddingRight: "2rem",
-            paddingBottom: "3rem",
-            maxWidth: "1280px",
-            margin: "0 auto",
-          }}
+          className="page-enter page-content-padded"
+          style={{ maxWidth: "1280px", margin: "0 auto" }}
         >
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "5fr 7fr",
-              gap: "2rem",
-              alignItems: "start",
-            }}
-          >
+          <div className="home-grid">
             {/* Search panel */}
             <div
               style={{
@@ -202,6 +188,7 @@ export default function RoutesPage() {
             >
               <div>
                 <h2
+                  className="home-headline"
                   style={{
                     fontSize: "2.5rem",
                     fontWeight: 800,
@@ -352,15 +339,7 @@ export default function RoutesPage() {
             </div>
 
             {/* Mapbox preview */}
-            <div
-              style={{
-                height: "600px",
-                borderRadius: "var(--radius-lg)",
-                position: "relative",
-                overflow: "hidden",
-                boxShadow: "var(--shadow-ambient)",
-              }}
-            >
+            <div className="home-map">
               {HAS_MAPBOX_TOKEN ? (
                 <div
                   ref={mapContainer}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -23,8 +23,8 @@ export default function ProfilePage() {
         <TopAppBar title="Profile" />
 
         <div
-          className="page-enter"
-          style={{ paddingTop: "88px", paddingLeft: "2rem", paddingRight: "2rem", paddingBottom: "3rem", maxWidth: "720px", margin: "0 auto" }}
+          className="page-enter page-content-padded"
+          style={{ maxWidth: "720px", margin: "0 auto" }}
         >
           {/* Avatar + name */}
           <div className="card-lg" style={{ padding: "2rem", display: "flex", alignItems: "center", gap: "1.5rem", marginBottom: "2rem" }}>

--- a/src/app/stop-details/page.tsx
+++ b/src/app/stop-details/page.tsx
@@ -55,6 +55,7 @@ function StopDetailsContent() {
             minHeight: "calc(100vh - 64px)",
             backgroundColor: "var(--color-surface-container-low)",
             padding: "2rem",
+            boxSizing: "border-box",
           }}
         >
           {/* Back Button */}
@@ -74,7 +75,7 @@ function StopDetailsContent() {
 
           {/* Stop Header */}
           <div
-            className="card-lg"
+            className="card-lg stop-header"
             style={{
               padding: "2rem",
               marginBottom: "2rem",
@@ -187,7 +188,7 @@ function StopDetailsContent() {
           <div
             style={{
               display: "grid",
-              gridTemplateColumns: "repeat(auto-fill, minmax(320px, 1fr))",
+              gridTemplateColumns: "repeat(auto-fill, minmax(min(280px, 100%), 1fr))",
               gap: "1rem",
             }}
           >

--- a/src/app/stops/page.tsx
+++ b/src/app/stops/page.tsx
@@ -220,21 +220,7 @@ export default function BusStopsPage() {
         )}
 
         {/* Search bar */}
-        <div
-          className="glass-panel"
-          style={{
-            position: "absolute",
-            top: 88,
-            left: 280,
-            right: "1.5rem",
-            borderRadius: "var(--radius-lg)",
-            padding: "0.75rem 1.25rem",
-            display: "flex",
-            alignItems: "center",
-            gap: "1rem",
-            zIndex: 10,
-          }}
-        >
+        <div className="stops-search-bar glass-panel">
           <span
             className="material-symbols-outlined"
             style={{ color: "var(--color-outline)", fontSize: "20px" }}
@@ -283,23 +269,7 @@ export default function BusStopsPage() {
         </div>
 
         {/* Stop list panel */}
-        <div
-          className="glass-panel"
-          style={{
-            position: "absolute",
-            bottom: "1.5rem",
-            right: 50,
-            width: 360,
-            maxHeight: "calc(100vh - 200px)",
-            borderRadius: "var(--radius-xl)",
-            padding: "1.5rem",
-            display: "flex",
-            flexDirection: "column",
-            gap: "0.875rem",
-            overflowY: "auto",
-            zIndex: 10,
-          }}
-        >
+        <div className="stops-list-panel glass-panel">
           <div
             style={{
               display: "flex",

--- a/src/app/tracking/page.tsx
+++ b/src/app/tracking/page.tsx
@@ -316,23 +316,7 @@ function TrackingContent() {
         )}
 
         {/* ── Info panel ───────────────────────────────────────────────────── */}
-        <div
-          className="glass-panel"
-          style={{
-            position: "absolute",
-            top: 88,
-            right: 32,
-            width: 360,
-            maxHeight: "calc(100vh - 112px)",
-            borderRadius: "var(--radius-xl)",
-            padding: "1.5rem",
-            display: "flex",
-            flexDirection: "column",
-            gap: "1.25rem",
-            overflowY: "auto",
-            zIndex: 10,
-          }}
-        >
+        <div className="tracking-info-panel glass-panel">
           {/* ── Bus header ──────────────────────────────────────────────── */}
           <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
             <div style={{

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const NAV_ITEMS = [
+  { href: "/",              icon: "search",         label: "Search"  },
+  { href: "/stops",         icon: "near_me",        label: "Stops"   },
+  { href: "/nearby",        icon: "directions_bus", label: "Routes"  },
+  { href: "/tracking",      icon: "map",            label: "Track"   },
+  { href: "/notifications", icon: "notifications",  label: "Alerts"  },
+];
+
+export default function BottomNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="bottom-nav" aria-label="Main navigation">
+      {NAV_ITEMS.map((item) => {
+        const isActive = pathname === item.href;
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={`bottom-nav-item${isActive ? " active" : ""}`}
+          >
+            <span
+              className="material-symbols-outlined"
+              style={{
+                fontSize: "22px",
+                fontVariationSettings: isActive ? "'FILL' 1" : "'FILL' 0",
+              }}
+            >
+              {item.icon}
+            </span>
+            <span>{item.label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `BottomNav` component (replaces hidden sidebar on mobile with a fixed bottom tab bar)
- Add viewport meta tag so mobile browsers scale correctly
- Home page two-column grid stacks vertically; map height reduces on mobile
- Stops page search bar and stop list panel repositioned as proper mobile overlays/bottom sheets
- Tracking page info panel becomes a bottom sheet on mobile
- Nearby buses sort chips scroll horizontally; bus cards stack on small phones
- Stop details route grid uses `min()` to prevent overflow on narrow screens
- Driver status grid collapses from 3 to 2 columns on mobile
- Shared `.page-content-padded` class handles responsive padding across all pages

## Test plan
- [x] Check home page on 375px wide viewport — search form above map, map visible
- [x] Check stops page — search bar flush to screen edges, stop list slides up from bottom
- [x] Check tracking page — info panel as bottom sheet, map still visible above
- [x] Check nearby buses page — sort chips scroll, bus card CTA goes full-width on small phones
- [x] Check stop details, notifications, profile, driver pages — content fits without horizontal scroll
- [x] Verify bottom nav appears on mobile and hides on desktop (≥769px)
- [x] Verify sidebar still shows on desktop